### PR TITLE
Pyproject.toml for Server

### DIFF
--- a/src/server/dcp_server/main.py
+++ b/src/server/dcp_server/main.py
@@ -1,9 +1,20 @@
 import subprocess
+from os import path
+
 
 def main(args=None):
     '''entry point to bentoml
     '''
-    subprocess.run(["bentoml","serve","service:svc","--reload","--port=7010"])
+    local_path = path.join(__file__, '..')
+    subprocess.run([
+        "bentoml",
+        "serve", 
+        '--working-dir', 
+        local_path,
+        "service:svc",
+        "--reload",
+        "--port=7010",
+    ])
     
 if __name__ == "__main__":
     main()

--- a/src/server/dcp_server/main.py
+++ b/src/server/dcp_server/main.py
@@ -1,0 +1,9 @@
+import subprocess
+
+def main(args=None):
+    '''entry point to bentoml
+    '''
+    subprocess.run(["bentoml","serve","service:svc","--reload","--port=7010"])
+    
+if __name__ == "__main__":
+    main()

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -2,14 +2,24 @@
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = ['dcp_server']
+
 [tool.setuptools.dynamic]
-#version = {attr = "my_package.VERSION"}
-readme = {file = "README.md"}
 dependencies = {file = ["requirements.txt"]}
 
 [project]
-name = "Data-centric-tool-server"
+name = "data-centric-tool-server"
 version = "0.1"
+requires-python = ">=3.9"
+description = ""
+# license = {file = "LICENSE.txt"}
+keywords = []
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+readme = "README.md"
 dynamic = ["dependencies"]
 authors = [
   {name="Christina Bukas", email="christina.bukas@helmholtz-muenchen.de"}
@@ -17,17 +27,16 @@ authors = [
 maintainers = [
   {name="Christina Bukas", email="christina.bukas@helmholtz-muenchen.de"}
 ]
-description = ""
-keywords = []
-readme = "README.md"
-requires-python = "==3.9"
-classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU Affero General Public License v3",
-    "Operating System :: OS Independent",
-]
 
 [project.optional-dependencies]
 dev = [
   "pytest",
 ]
+
+[project.urls]
+repository = "https://github.com/HelmholtzAI-Consultants-Munich/data-centric-platform"
+# homepage = "https://example.com"
+# documentation = "https://readthedocs.org"
+
+[project.scripts]
+dcp-server = "dcp_server.main:main"

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -22,10 +22,12 @@ classifiers = [
 readme = "README.md"
 dynamic = ["dependencies"]
 authors = [
-  {name="Christina Bukas", email="christina.bukas@helmholtz-muenchen.de"}
+  {name="Christina Bukas", email="christina.bukas@helmholtz-muenchen.de"},
+  {name="Helena Pelin", email="helena.pelin@helmholtz-muenchen.de"}
 ]
 maintainers = [
-  {name="Christina Bukas", email="christina.bukas@helmholtz-muenchen.de"}
+  {name="Christina Bukas", email="christina.bukas@helmholtz-muenchen.de"},
+  {name="Helena Pelin", email="helena.pelin@helmholtz-muenchen.de"}
 ]
 
 [project.optional-dependencies]

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = {file = ["requirements.txt"]}
 [project]
 name = "data-centric-tool-server"
 version = "0.1"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 description = ""
 # license = {file = "LICENSE.txt"}
 keywords = []

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+#version = {attr = "my_package.VERSION"}
+readme = {file = "README.md"}
+dependencies = {file = ["requirements.txt"]}
+
+[project]
+name = "Data-centric-tool-server"
+version = "0.1"
+dynamic = ["dependencies"]
+authors = [
+  {name="Christina Bukas", email="christina.bukas@helmholtz-muenchen.de"}
+]
+maintainers = [
+  {name="Christina Bukas", email="christina.bukas@helmholtz-muenchen.de"}
+]
+description = ""
+keywords = []
+readme = "README.md"
+requires-python = "==3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
+    "Operating System :: OS Independent",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+]


### PR DESCRIPTION
Hi,

Building on the work done in the coding club, this commit has the pyproject.toml file set up to deploy the server to PyPI, so that once installed the user can simply type `dcp-server` and have it run.

Notably, this also makes it possible to install the whole project locally with `pip install .` (for example, this could be useful for a docker build command to share build settings)

I hope this helps!

Best wishes,

Nick