### PR TITLE
Client pyinstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
+
 
 # Installer logs
 pip-log.txt

--- a/src/client/dcp_client/main.py
+++ b/src/client/dcp_client/main.py
@@ -1,14 +1,18 @@
 import sys
 from PyQt5.QtWidgets import QApplication
-from welcome_window import WelcomeWindow
+from .welcome_window import WelcomeWindow
 
 import warnings
 warnings.simplefilter('ignore')
 
-import settings
-settings.init()
 
-if __name__ == "__main__":
+def main():
+    import settings
+    settings.init()
     app = QApplication(sys.argv)
     window = WelcomeWindow()
     sys.exit(app.exec())
+
+if __name__ == "__main__":
+    main()
+    

--- a/src/client/dcp_client/main.spec
+++ b/src/client/dcp_client/main.spec
@@ -1,0 +1,54 @@
+# -*- mode: python ; coding: utf-8 -*-
+from PyInstaller.utils.hooks import copy_metadata
+
+
+datas += copy_metadata('cattrs')
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['main.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[('/Users/donatella.cea/opt/anaconda3/envs/dcp-env/lib/python3.9/site-packages/bentoml/_internal/configuration/v1/default_configuration.yaml', '.')],
+    hiddenimports=['cattrs'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='main',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='main',
+)

--- a/src/client/dcp_client/main_window.py
+++ b/src/client/dcp_client/main_window.py
@@ -3,8 +3,8 @@ from PyQt5.QtWidgets import QWidget, QPushButton, QVBoxLayout, QFileSystemModel,
 from PyQt5.QtCore import Qt
 from bentoml.client import Client
 
-import settings
-from utils import IconProvider, create_warning_box
+from . import settings
+from .utils import IconProvider, create_warning_box
 from napari_window import NapariWindow
 
 class MainWindow(QWidget):

--- a/src/client/dcp_client/run_client.spec
+++ b/src/client/dcp_client/run_client.spec
@@ -1,19 +1,15 @@
 # -*- mode: python ; coding: utf-8 -*-
-from PyInstaller.utils.hooks import copy_metadata
-
-
-datas += copy_metadata('cattrs')
 
 
 block_cipher = None
 
 
 a = Analysis(
-    ['main.py'],
-    pathex=['.'],
+    ['run_client.py'],
+    pathex=[],
     binaries=[],
-    datas=[('/Users/donatella.cea/opt/anaconda3/envs/dcp-env/lib/python3.9/site-packages/bentoml/_internal/configuration/v1/default_configuration.yaml', '.')],
-    hiddenimports=['cattrs'],
+    datas=[],
+    hiddenimports=[],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -30,7 +26,7 @@ exe = EXE(
     a.scripts,
     [],
     exclude_binaries=True,
-    name='main',
+    name='run_client',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
@@ -50,5 +46,5 @@ coll = COLLECT(
     strip=False,
     upx=True,
     upx_exclude=[],
-    name='main',
+    name='run_client',
 )

--- a/src/client/dcp_client/welcome_window.py
+++ b/src/client/dcp_client/welcome_window.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLabel, QFileDialog, QLineEdit
 from PyQt5.QtCore import Qt
 
-from main_window import MainWindow
+from .main_window import MainWindow
 from utils import create_warning_box
 
 class WelcomeWindow(QWidget):

--- a/src/client/run_client.py
+++ b/src/client/run_client.py
@@ -1,0 +1,3 @@
+from dcp_client.main import main
+
+main()

--- a/src/client/run_client.spec
+++ b/src/client/run_client.spec
@@ -1,0 +1,50 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['run_client.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['importlib_metadata'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='run_client',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='run_client',
+)


### PR DESCRIPTION
Hi,

This pull request builds on the pyinstaller client work from the coding club session.  Unfortunatly, it still doesn't work--for some reason, there's a hidden import in Bento that uses cattrs that doesn't seem to be going properly into the pyinstaller distribution.  Error below:

```
  File "dcp_client/main_window.py", line 4, in <module>
    from bentoml.client import Client
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "bentoml/__init__.py", line 25, in <module>
  File "bentoml/_internal/configuration/__init__.py", line 137, in load_config
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "bentoml/_internal/configuration/containers.py", line 19, in <module>
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "bentoml/_internal/utils/__init__.py", line 33, in <module>
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "bentoml/_internal/utils/cattr.py", line 12, in <module>
  File "bentoml/_internal/utils/pkg.py", line 32, in pkg_version_info
  File "importlib/metadata.py", line 569, in version
  File "importlib/metadata.py", line 542, in distribution
  File "importlib/metadata.py", line 196, in from_name
importlib.metadata.PackageNotFoundError: cattrs
[121891] Failed to execute script 'run_client' due to unhandled exception!
```

Best wishes,

Nick