### PR TITLE
fix bentoml version on requirements

### DIFF
--- a/src/client/requirements.txt
+++ b/src/client/requirements.txt
@@ -1,3 +1,3 @@
 napari[pyqt5]>=0.4.17
-bentoml[grpc]>=1.0.13
+bentoml[grpc]==1.0.16
 pytest>=7.4.3

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -1,5 +1,5 @@
 cellpose>=2.2
-bentoml>=1.0.13
+bentoml==1.0.16
 scikit-image>=0.19.3
 torchmetrics>=0.11.4
 torch>=2.1.0


### PR DESCRIPTION
Temporary fix to address #53. Bentoml version is fixed to 1.0.16. 
Added a new issue to eventually make scp compatible with future versions of bentoml