### PR TITLE
Fix MobileSAM loading on CPU-only clients.

### DIFF
--- a/src/client/dcp_client/utils/ai_assistance/sam_worker.py
+++ b/src/client/dcp_client/utils/ai_assistance/sam_worker.py
@@ -99,18 +99,18 @@ class SAMInferenceWorker(QThread):
     def _initialize_predictor(self):
         """Initialize SAM predictor in worker thread."""
         try:
-            from segment_anything import sam_model_registry, SamPredictor
-            
-            # Select model
             model_type = self.model_manager.select_model()
             device = self.model_manager.get_device()
             self.device = device
-            
-            # Get checkpoint path
             checkpoint_path = self.model_manager.get_checkpoint_path(model_type)
-            
-            # Load model
-            sam = sam_model_registry[model_type](checkpoint=str(checkpoint_path))
+            registry_model_type = self.model_manager.get_registry_model_type(model_type)
+
+            if self.model_manager.uses_mobile_sam(model_type):
+                from mobile_sam import sam_model_registry, SamPredictor
+            else:
+                from segment_anything import sam_model_registry, SamPredictor
+
+            sam = sam_model_registry[registry_model_type](checkpoint=str(checkpoint_path))
             sam.to(device=device)
             
             # Create predictor

--- a/src/client/dcp_client/utils/sam_model_manager.py
+++ b/src/client/dcp_client/utils/sam_model_manager.py
@@ -128,6 +128,16 @@ class SAMModelManager:
         print(f"Checkpoint downloaded to {checkpoint_path}")
         return checkpoint_path
     
+    def uses_mobile_sam(self, model_type: str) -> bool:
+        """Return True if model_type requires the mobile_sam package."""
+        return model_type == "mobilesam"
+
+    def get_registry_model_type(self, model_type: str) -> str:
+        """Map internal model type to the key used by sam_model_registry."""
+        if model_type == "mobilesam":
+            return "vit_t"
+        return model_type
+
     def get_device(self) -> str:
         """
         Get best device for current hardware.

--- a/src/client/setup.py
+++ b/src/client/setup.py
@@ -64,6 +64,7 @@ setup(
         "scipy >=1.10", 
         "napari[pyqt5]>=0.4.17",
         "segment-anything @ git+https://github.com/facebookresearch/segment-anything.git@main",
+        "mobile_sam @ git+https://github.com/ChaoningZhang/MobileSAM.git@master",
         "torch",
         "torchvision",
         "bentoml[grpc]>=1.2.5"

--- a/src/client/setup.py
+++ b/src/client/setup.py
@@ -64,7 +64,7 @@ setup(
         "scipy >=1.10", 
         "napari[pyqt5]>=0.4.17",
         "segment-anything @ git+https://github.com/facebookresearch/segment-anything.git@main",
-        "mobile_sam @ git+https://github.com/ChaoningZhang/MobileSAM.git@master",
+        "mobile_sam @ git+https://github.com/ChaoningZhang/MobileSAM.git@f706ad9c4eb7f219c00d9050e46328518ffb65d2",
         "torch",
         "torchvision",
         "bentoml[grpc]>=1.2.5"


### PR DESCRIPTION
Use the mobile_sam package with vit_t registry key when mobilesam is selected, since segment_anything does not support that checkpoint.